### PR TITLE
chore(ci): stop running pre-commit with github actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,14 +22,3 @@ jobs:
           python -m pip install tox tox-gh-actions
       - name: Run tests
         run: tox
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: "3.7"
-      - name: Install requirements
-        run: |
-          python -m pip install -r requirements-dev.txt
-      - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Moving to https://pre-commit.ci/